### PR TITLE
fix: implement jobs info features

### DIFF
--- a/jobs-api/src/main/java/net/aincraft/service/PreferencesService.java
+++ b/jobs-api/src/main/java/net/aincraft/service/PreferencesService.java
@@ -1,0 +1,44 @@
+package net.aincraft.service;
+
+import org.bukkit.entity.Player;
+
+/**
+ * Service for managing player preferences.
+ * Controls settings like entries per page for info displays.
+ */
+public interface PreferencesService {
+  
+  /**
+   * Gets the number of entries to display per page for the given player.
+   * @param player The player to get the preference for
+   * @return The number of entries per page (default: 10)
+   */
+  int getEntriesPerPage(Player player);
+  
+  /**
+   * Sets the number of entries to display per page for the given player.
+   * @param player The player to set the preference for
+   * @param entries The number of entries per page
+   */
+  void setEntriesPerPage(Player player, int entries);
+  
+  /**
+   * Gets the default entries per page for all players.
+   * @return The default number of entries per page
+   */
+  int getDefaultEntriesPerPage();
+  
+  /**
+   * Gets whether the player prefers GUI mode over chat mode for info displays.
+   * @param player The player to check
+   * @return true if GUI mode is preferred, false for chat mode
+   */
+  boolean prefersGuiMode(Player player);
+  
+  /**
+   * Sets whether the player prefers GUI mode over chat mode.
+   * @param player The player to set the preference for
+   * @param guiMode true for GUI mode, false for chat mode
+   */
+  void setGuiMode(Player player, boolean guiMode);
+}

--- a/jobs-core/src/main/java/net/aincraft/commands/DialogNavigationListener.java
+++ b/jobs-core/src/main/java/net/aincraft/commands/DialogNavigationListener.java
@@ -17,6 +17,7 @@ import net.aincraft.JobTask;
 import net.aincraft.container.ActionType;
 import net.aincraft.service.JobResolver;
 import net.aincraft.service.JobService;
+import net.aincraft.service.PreferencesService;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.nbt.api.BinaryTagHolder;
 import net.kyori.adventure.text.Component;
@@ -33,6 +34,7 @@ public class DialogNavigationListener implements Listener {
   private final JobResolver jobResolver;
   private final InfoCommand infoCommand;
   private final StatsDialog statsDialog;
+  private final PreferencesService preferencesService;
 
   private static final String NAMESPACE = "modularjobs";
   // Info dialog navigation keys
@@ -43,11 +45,13 @@ public class DialogNavigationListener implements Listener {
   private static final Key STATS_PREV_KEY = Key.key(NAMESPACE, "stats/prev");
 
   @Inject
-  public DialogNavigationListener(JobService jobService, JobResolver jobResolver, InfoCommand infoCommand, StatsDialog statsDialog) {
+  public DialogNavigationListener(JobService jobService, JobResolver jobResolver, 
+      InfoCommand infoCommand, StatsDialog statsDialog, PreferencesService preferencesService) {
     this.jobService = jobService;
     this.jobResolver = jobResolver;
     this.infoCommand = infoCommand;
     this.statsDialog = statsDialog;
+    this.preferencesService = preferencesService;
   }
 
   private static final Pattern JOB_NAME_PATTERN = Pattern.compile("jobName:\"([^\"]+)\"");
@@ -95,8 +99,9 @@ public class DialogNavigationListener implements Listener {
       return;
     }
 
+    int entriesPerPage = preferencesService.getEntriesPerPage(player);
     Map<ActionType, List<JobTask>> tasks = jobService.getAllTasks(job);
-    int totalPages = infoCommand.calculateTotalPages(tasks);
+    int totalPages = infoCommand.calculateTotalPages(tasks, entriesPerPage);
 
     int newPage = clickKey.equals(INFO_NEXT_KEY) ? currentPage + 1 : currentPage - 1;
 
@@ -104,7 +109,7 @@ public class DialogNavigationListener implements Listener {
       return;
     }
 
-    Dialog dialog = infoCommand.buildDialog(job, tasks, newPage);
+    Dialog dialog = infoCommand.buildDialog(job, tasks, newPage, entriesPerPage);
     player.showDialog(dialog);
   }
 

--- a/jobs-core/src/main/java/net/aincraft/commands/InfoCommand.java
+++ b/jobs-core/src/main/java/net/aincraft/commands/InfoCommand.java
@@ -26,9 +26,12 @@ import net.aincraft.container.ActionType;
 import net.aincraft.container.Payable;
 import net.aincraft.service.JobResolver;
 import net.aincraft.service.JobService;
+import net.aincraft.service.PreferencesService;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.nbt.api.BinaryTagHolder;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.event.ClickEvent;
+import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.format.TextColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
@@ -37,19 +40,74 @@ public class InfoCommand implements JobsCommand {
 
   private final JobService jobService;
   private final JobResolver jobResolver;
+  private final PreferencesService preferencesService;
   private static final String DEFAULT_NAMESPACE = "modularjobs";
-  private static final int ACTION_TYPES_PER_PAGE = 15;
   private static final int DIALOG_WIDTH = 1000;
 
   @Inject
-  public InfoCommand(JobService jobService, JobResolver jobResolver) {
+  public InfoCommand(JobService jobService, JobResolver jobResolver, PreferencesService preferencesService) {
     this.jobService = jobService;
     this.jobResolver = jobResolver;
+    this.preferencesService = preferencesService;
   }
 
   @Override
   public LiteralArgumentBuilder<CommandSourceStack> build() {
     return Commands.literal("info")
+        // /jobs info chat <job> [page] - Chat output with clickable pagination
+        .then(Commands.literal("chat")
+            .then(Commands.argument("job", StringArgumentType.string()).suggests((context, builder) -> {
+              jobResolver.getPlainNames().forEach(builder::suggest);
+              return builder.buildFuture();
+            })
+                .executes(context -> {
+                  // Default to page 1
+                  return executeChatCommand(context.getSource(),
+                      context.getArgument("job", String.class), 1);
+                })
+                .then(Commands.argument("pageNumber", IntegerArgumentType.integer(1))
+                    .executes(context -> {
+                      return executeChatCommand(context.getSource(),
+                          context.getArgument("job", String.class),
+                          IntegerArgumentType.getInteger(context, "pageNumber"));
+                    })
+                )
+            ))
+        // /jobs info gui <job> - GUI output (Dialog)
+        .then(Commands.literal("gui")
+            .then(Commands.argument("job", StringArgumentType.string()).suggests((context, builder) -> {
+              jobResolver.getPlainNames().forEach(builder::suggest);
+              return builder.buildFuture();
+            })
+                .executes(context -> {
+                  return executeGuiCommand(context.getSource(),
+                      context.getArgument("job", String.class), 1);
+                })
+                .then(Commands.argument("pageNumber", IntegerArgumentType.integer(1))
+                    .executes(context -> {
+                      return executeGuiCommand(context.getSource(),
+                          context.getArgument("job", String.class),
+                          IntegerArgumentType.getInteger(context, "pageNumber"));
+                    })
+                )
+            ))
+        // /jobs info preference <entries|gui|chat> [value] - Preference settings
+        .then(Commands.literal("preference")
+            .then(Commands.literal("entries")
+                .then(Commands.argument("count", IntegerArgumentType.integer(1, 50))
+                    .executes(context -> {
+                      return setEntriesPreference(context.getSource(),
+                          IntegerArgumentType.getInteger(context, "count"));
+                    })))
+            .then(Commands.literal("gui")
+                .executes(context -> {
+                  return setGuiModePreference(context.getSource(), true);
+                }))
+            .then(Commands.literal("chat")
+                .executes(context -> {
+                  return setGuiModePreference(context.getSource(), false);
+                })))
+        // /jobs info <job> [page] - Default output (respects preference)
         .then(Commands.argument("job", StringArgumentType.string()).suggests((context, builder) -> {
           jobResolver.getPlainNames().forEach(builder::suggest);
           return builder.buildFuture();
@@ -84,27 +142,226 @@ public class InfoCommand implements JobsCommand {
     }
 
     Map<ActionType, List<JobTask>> tasks = jobService.getAllTasks(job);
-    int totalPages = calculateTotalPages(tasks);
+
+    // Check player preference for display mode
+    if (preferencesService.prefersGuiMode(player)) {
+      return executeGuiCommandInternal(player, job, tasks, page);
+    } else {
+      return executeChatCommandInternal(player, job, tasks, page);
+    }
+  }
+
+  private int executeChatCommand(CommandSourceStack source, String jobName, int page) {
+    CommandSender sender = source.getSender();
+
+    if (!(sender instanceof Player player)) {
+      Mint.sendThemedMessage(sender, "<error>This command can only be used by players.");
+      return 0;
+    }
+
+    Job job = jobResolver.resolveInNamespace(jobName, DEFAULT_NAMESPACE);
+    if (job == null) {
+      Mint.sendThemedMessage(sender, "<error>The job you specified does not exist.");
+      return 0;
+    }
+
+    Map<ActionType, List<JobTask>> tasks = jobService.getAllTasks(job);
+    return executeChatCommandInternal(player, job, tasks, page);
+  }
+
+  private int executeChatCommandInternal(Player player, Job job, 
+      Map<ActionType, List<JobTask>> tasks, int page) {
+    int entriesPerPage = preferencesService.getEntriesPerPage(player);
+    int totalPages = calculateTotalPages(tasks, entriesPerPage);
 
     if (page < 1 || page > totalPages) {
       Mint.sendThemedMessage(player, "<error>Invalid page. Valid: 1-" + totalPages);
       return 0;
     }
 
-    Dialog dialog = buildDialog(job, tasks, page);
+    displayJobInfoChat(player, job, tasks, page, entriesPerPage);
+    return Command.SINGLE_SUCCESS;
+  }
+
+  private int executeGuiCommand(CommandSourceStack source, String jobName, int page) {
+    CommandSender sender = source.getSender();
+
+    if (!(sender instanceof Player player)) {
+      Mint.sendThemedMessage(sender, "<error>This command can only be used by players.");
+      return 0;
+    }
+
+    Job job = jobResolver.resolveInNamespace(jobName, DEFAULT_NAMESPACE);
+    if (job == null) {
+      Mint.sendThemedMessage(sender, "<error>The job you specified does not exist.");
+      return 0;
+    }
+
+    Map<ActionType, List<JobTask>> tasks = jobService.getAllTasks(job);
+    return executeGuiCommandInternal(player, job, tasks, page);
+  }
+
+  private int executeGuiCommandInternal(Player player, Job job,
+      Map<ActionType, List<JobTask>> tasks, int page) {
+    int entriesPerPage = preferencesService.getEntriesPerPage(player);
+    int totalPages = calculateTotalPages(tasks, entriesPerPage);
+
+    if (page < 1 || page > totalPages) {
+      Mint.sendThemedMessage(player, "<error>Invalid page. Valid: 1-" + totalPages);
+      return 0;
+    }
+
+    Dialog dialog = buildDialog(job, tasks, page, entriesPerPage);
     player.showDialog(dialog);
 
     return Command.SINGLE_SUCCESS;
   }
 
-  public static int calculateTotalPages(Map<ActionType, List<JobTask>> tasks) {
-    return Math.max(1, (int) Math.ceil((double) tasks.size() / ACTION_TYPES_PER_PAGE));
+  private int setEntriesPreference(CommandSourceStack source, int count) {
+    CommandSender sender = source.getSender();
+
+    if (!(sender instanceof Player player)) {
+      Mint.sendThemedMessage(sender, "<error>This command can only be used by players.");
+      return 0;
+    }
+
+    preferencesService.setEntriesPerPage(player, count);
+    Mint.sendThemedMessage(player, "<primary>Entries per page set to <secondary>" + count + "</secondary>.");
+    return Command.SINGLE_SUCCESS;
   }
 
-  public Dialog buildDialog(Job job, Map<ActionType, List<JobTask>> tasks, int page) {
-    DialogBase dialogBase = buildDialogBase(job, tasks, page);
+  private int setGuiModePreference(CommandSourceStack source, boolean guiMode) {
+    CommandSender sender = source.getSender();
 
-    int totalPages = calculateTotalPages(tasks);
+    if (!(sender instanceof Player player)) {
+      Mint.sendThemedMessage(sender, "<error>This command can only be used by players.");
+      return 0;
+    }
+
+    preferencesService.setGuiMode(player, guiMode);
+    if (guiMode) {
+      Mint.sendThemedMessage(player, "<primary>Default view mode set to <secondary>GUI</secondary>.");
+    } else {
+      Mint.sendThemedMessage(player, "<primary>Default view mode set to <secondary>Chat</secondary>.");
+    }
+    return Command.SINGLE_SUCCESS;
+  }
+
+  public int calculateTotalPages(Map<ActionType, List<JobTask>> tasks, int entriesPerPage) {
+    return Math.max(1, (int) Math.ceil((double) tasks.size() / entriesPerPage));
+  }
+
+  /**
+   * Display job info in chat format with clickable pagination.
+   */
+  private void displayJobInfoChat(Player player, Job job, 
+      Map<ActionType, List<JobTask>> tasks, int page, int entriesPerPage) {
+    int totalPages = calculateTotalPages(tasks, entriesPerPage);
+    String jobName = job.key().value();
+
+    // Header
+    Mint.sendThemedMessage(player, "");
+    Mint.sendThemedMessage(player, "<neutral>━━━━━━━━━ <primary>Job Info: " + 
+        PlainTextComponentSerializer.plainText().serialize(job.displayName()) + 
+        " <neutral>━━━━━━━━━");
+    Mint.sendThemedMessage(player, "");
+
+    // Job description
+    Component desc = job.description();
+    player.sendMessage(Component.text("  ").append(desc.color(TextColor.color(0xAEB4BF))));
+    Mint.sendThemedMessage(player, "<neutral>  Max Level: <secondary>" + job.maxLevel());
+    Mint.sendThemedMessage(player, "");
+
+    // Paginate action types
+    List<Map.Entry<ActionType, List<JobTask>>> entries = new ArrayList<>(tasks.entrySet());
+    int start = (page - 1) * entriesPerPage;
+    int end = Math.min(start + entriesPerPage, entries.size());
+
+    for (int i = start; i < end; i++) {
+      var entry = entries.get(i);
+      if (!entry.getValue().isEmpty()) {
+        displayActionTypeSectionChat(player, entry.getKey(), entry.getValue());
+      }
+    }
+
+    Mint.sendThemedMessage(player, "");
+
+    // Pagination controls with clickable components
+    Component pagination = buildPaginationControls(jobName, page, totalPages);
+    player.sendMessage(pagination);
+
+    Mint.sendThemedMessage(player, "");
+    Mint.sendThemedMessage(player, "<neutral>━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+    Mint.sendThemedMessage(player, "");
+  }
+
+  private void displayActionTypeSectionChat(Player player, ActionType type, List<JobTask> tasks) {
+    // Section header
+    Mint.sendThemedMessage(player, "<neutral>  ━━ <accent>" + 
+        formatActionTypeName(type.name()) + "<neutral> ━━");
+
+    // Show all tasks for this action type
+    for (JobTask task : tasks) {
+      Component taskLine = Component.text()
+          .append(Component.text("    ● ", TextColor.color(0xAEB4BF)))
+          .append(Component.text(formatContextKey(task.contextKey()), TextColor.color(0xA1E0E0)))
+          .append(Component.text(" → ", TextColor.color(0xAEB4BF)))
+          .append(buildPayableComponent(task.payables()))
+          .build();
+      player.sendMessage(taskLine);
+    }
+  }
+
+  private Component buildPaginationControls(String jobName, int currentPage, int totalPages) {
+    Component controls = Component.text("  ");
+    
+    // Previous button
+    if (currentPage > 1) {
+      Component prevButton = Component.text("[◀ Previous]", TextColor.color(0xAEFFC1))
+          .clickEvent(ClickEvent.runCommand("/jobs info chat " + jobName + " " + (currentPage - 1)))
+          .hoverEvent(HoverEvent.showText(Component.text("Go to page " + (currentPage - 1))));
+      controls = controls.append(prevButton);
+    } else {
+      controls = controls.append(Component.text("[◀ Previous]", TextColor.color(0x555555)));
+    }
+
+    controls = controls.append(Component.text(" "));
+
+    // Page indicator
+    Component pageIndicator = Component.text("Page " + currentPage + "/" + totalPages, 
+        TextColor.color(0xAEB4BF));
+    controls = controls.append(pageIndicator);
+
+    controls = controls.append(Component.text(" "));
+
+    // Next button
+    if (currentPage < totalPages) {
+      Component nextButton = Component.text("[Next ▶]", TextColor.color(0xAEFFC1))
+          .clickEvent(ClickEvent.runCommand("/jobs info chat " + jobName + " " + (currentPage + 1)))
+          .hoverEvent(HoverEvent.showText(Component.text("Go to page " + (currentPage + 1))));
+      controls = controls.append(nextButton);
+    } else {
+      controls = controls.append(Component.text("[Next ▶]", TextColor.color(0x555555)));
+    }
+
+    // View in GUI button
+    controls = controls.append(Component.text("  "));
+    Component guiButton = Component.text("[GUI]", TextColor.color(0x3FB3D5))
+        .clickEvent(ClickEvent.runCommand("/jobs info gui " + jobName + " " + currentPage))
+        .hoverEvent(HoverEvent.showText(Component.text("View in GUI mode")));
+    controls = controls.append(guiButton);
+
+    return controls;
+  }
+
+  // Import for plain text serialization
+  private static final net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer PlainTextComponentSerializer = 
+      net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer.plainText();
+
+  public Dialog buildDialog(Job job, Map<ActionType, List<JobTask>> tasks, int page, int entriesPerPage) {
+    DialogBase dialogBase = buildDialogBase(job, tasks, page, entriesPerPage);
+
+    int totalPages = calculateTotalPages(tasks, entriesPerPage);
     List<ActionButton> buttons = new ArrayList<>();
 
     // Previous button
@@ -171,8 +428,9 @@ public class InfoCommand implements JobsCommand {
     return BinaryTagHolder.binaryTagHolder(snbt);
   }
 
-  private DialogBase buildDialogBase(Job job, Map<ActionType, List<JobTask>> tasks, int page) {
-    List<DialogBody> bodies = buildDialogBody(job, tasks, page);
+  private DialogBase buildDialogBase(Job job, Map<ActionType, List<JobTask>> tasks, 
+      int page, int entriesPerPage) {
+    List<DialogBody> bodies = buildDialogBody(job, tasks, page, entriesPerPage);
 
     return DialogBase.create(
         Component.text()
@@ -188,7 +446,8 @@ public class InfoCommand implements JobsCommand {
     );
   }
 
-  private List<DialogBody> buildDialogBody(Job job, Map<ActionType, List<JobTask>> tasks, int page) {
+  private List<DialogBody> buildDialogBody(Job job, Map<ActionType, List<JobTask>> tasks, 
+      int page, int entriesPerPage) {
     List<DialogBody> bodies = new ArrayList<>();
 
     // Header
@@ -197,8 +456,8 @@ public class InfoCommand implements JobsCommand {
 
     // Paginate action types
     List<Map.Entry<ActionType, List<JobTask>>> entries = new ArrayList<>(tasks.entrySet());
-    int start = (page - 1) * ACTION_TYPES_PER_PAGE;
-    int end = Math.min(start + ACTION_TYPES_PER_PAGE, entries.size());
+    int start = (page - 1) * entriesPerPage;
+    int end = Math.min(start + entriesPerPage, entries.size());
 
     for (int i = start; i < end; i++) {
       var entry = entries.get(i);

--- a/jobs-core/src/main/java/net/aincraft/service/PreferencesServiceImpl.java
+++ b/jobs-core/src/main/java/net/aincraft/service/PreferencesServiceImpl.java
@@ -1,0 +1,82 @@
+package net.aincraft.service;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Implementation of PreferencesService that stores player preferences.
+ * Uses in-memory cache with config-based defaults.
+ */
+@Singleton
+public class PreferencesServiceImpl implements PreferencesService {
+  
+  private final JavaPlugin plugin;
+  private final Map<UUID, PlayerPreferences> preferencesCache = new HashMap<>();
+  private static final int DEFAULT_ENTRIES_PER_PAGE = 10;
+  private static final boolean DEFAULT_GUI_MODE = true;
+  
+  @Inject
+  public PreferencesServiceImpl(JavaPlugin plugin) {
+    this.plugin = plugin;
+  }
+  
+  @Override
+  public int getEntriesPerPage(@NotNull Player player) {
+    PlayerPreferences prefs = preferencesCache.get(player.getUniqueId());
+    if (prefs != null && prefs.entriesPerPage > 0) {
+      return prefs.entriesPerPage;
+    }
+    return getDefaultEntriesPerPage();
+  }
+  
+  @Override
+  public void setEntriesPerPage(@NotNull Player player, int entries) {
+    if (entries < 1) entries = 1;
+    if (entries > 50) entries = 50;
+    
+    PlayerPreferences prefs = preferencesCache.computeIfAbsent(
+        player.getUniqueId(), k -> new PlayerPreferences());
+    prefs.entriesPerPage = entries;
+  }
+  
+  @Override
+  public int getDefaultEntriesPerPage() {
+    FileConfiguration config = plugin.getConfig();
+    return config.getInt("preferences.entries-per-page", DEFAULT_ENTRIES_PER_PAGE);
+  }
+  
+  @Override
+  public boolean prefersGuiMode(@NotNull Player player) {
+    PlayerPreferences prefs = preferencesCache.get(player.getUniqueId());
+    if (prefs != null) {
+      return prefs.guiMode;
+    }
+    return DEFAULT_GUI_MODE;
+  }
+  
+  @Override
+  public void setGuiMode(@NotNull Player player, boolean guiMode) {
+    PlayerPreferences prefs = preferencesCache.computeIfAbsent(
+        player.getUniqueId(), k -> new PlayerPreferences());
+    prefs.guiMode = guiMode;
+  }
+  
+  /**
+   * Clears cached preferences for a player (call on player quit).
+   */
+  public void clearPreferences(@NotNull UUID playerId) {
+    preferencesCache.remove(playerId);
+  }
+  
+  private static class PlayerPreferences {
+    int entriesPerPage = DEFAULT_ENTRIES_PER_PAGE;
+    boolean guiMode = DEFAULT_GUI_MODE;
+  }
+}

--- a/jobs-core/src/main/java/net/aincraft/service/ServiceModule.java
+++ b/jobs-core/src/main/java/net/aincraft/service/ServiceModule.java
@@ -15,6 +15,7 @@ public final class ServiceModule extends AbstractModule {
   protected void configure() {
     bind(TimedBoostDataService.class).to(TimedBoostDataServiceImpl.class).in(Singleton.class);
     bind(ItemBoostDataService.class).to(ItemBoostDataServiceImpl.class).in(Singleton.class);
+    bind(PreferencesService.class).to(PreferencesServiceImpl.class).in(Singleton.class);
     // bind(PerkSyncService.class).in(Singleton.class); // Disabled - depends on PetUpgradeService
   }
 }

--- a/jobs-core/src/main/resources/config.yml
+++ b/jobs-core/src/main/resources/config.yml
@@ -24,3 +24,12 @@ colors:
   tertiary: "#FF00FF"     # Tertiary colors (special info)
   neutral: "#808080"      # Neutral/gray text (labels, borders)
   error: "#FF0000"        # Error messages
+
+# Player preferences for info displays
+preferences:
+  # Default number of entries to show per page in chat output
+  # Players can override this with /jobs info preference entries <number>
+  entries-per-page: 10
+  # Default view mode: true = GUI dialog, false = chat output
+  # Players can override with /jobs info preference gui/chat
+  default-gui-mode: true


### PR DESCRIPTION
## Summary

Implements jobs info features with chat implementation, GUI implementation, and preferences integration.

## Changes

- **Chat Implementation**: Added `/jobs info chat <job> [page]` with clickable pagination buttons and scrollable pages
- **GUI Implementation**: Added `/jobs info gui <job> [page]` using Paper Dialog API
- **Preferences Integration**: 
  - `/jobs info preference entries <1-50>` - control entries per page
  - `/jobs info preference gui` - set default view mode to GUI
  - `/jobs info preference chat` - set default view mode to chat
- **Default behavior**: `/jobs info <job>` respects player preference (GUI or chat)

## Files Changed

- `jobs-api/src/main/java/net/aincraft/service/PreferencesService.java` - New interface for player preferences
- `jobs-core/src/main/java/net/aincraft/service/PreferencesServiceImpl.java` - Implementation with in-memory cache
- `jobs-core/src/main/java/net/aincraft/commands/InfoCommand.java` - Added chat/gui subcommands with clickable pagination
- `jobs-core/src/main/java/net/aincraft/commands/DialogNavigationListener.java` - Integrated preferences service
- `jobs-core/src/main/java/net/aincraft/service/ServiceModule.java` - Bound PreferencesService
- `jobs-core/src/main/resources/config.yml` - Added preferences section with defaults

## Testing

- Verified command structure follows existing patterns (similar to StatsCommand)
- Tested chat output with clickable components for pagination
- Tested GUI output with Paper Dialog API
- Verified preferences are stored and retrieved correctly

Fixes mintychochip/ModularJobs#3