### PR TITLE
feat: profession-gated block breaking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,12 +47,93 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+
       - name: Set up JDK 25
         uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: "25"
           cache: gradle
+
+      - name: Checkout craftux dependency (pinned release)
+        uses: actions/checkout@v4
+        with:
+          repository: aincraft-org/craftux
+          ref: 402bea8ce21847df632a10b00b563665db205de
+          path: craftux
+          fetch-depth: 1
+
+      - name: Link craftux local Maven repository
+        run: ln -s "$GITHUB_WORKSPACE/craftux" "$GITHUB_WORKSPACE/../craftux"
+
+      - name: Set up Rust for craftux views
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Publish craftux local Maven artifacts
+        working-directory: craftux
+        run: |
+          chmod +x gradlew
+          ./gradlew \
+            :api:publishMavenPublicationToLocalBuildRepository \
+            :common:publishMavenPublicationToLocalBuildRepository \
+            :paper:publishMavenPublicationToLocalBuildRepository \
+            --console=plain --no-daemon
+      - name: Require mint repository token
+        env:
+          MINT_REPO_TOKEN: ${{ secrets.MINT_REPO_TOKEN }}
+        run: |
+          if [[ -z "$MINT_REPO_TOKEN" ]]; then
+            echo "::error::ModularJobs needs aincraft-org/mint. Add a repo-scope PAT as MINT_REPO_TOKEN."
+            exit 1
+          fi
+
+      - name: Checkout mint dependency (private, pinned source)
+        uses: actions/checkout@v4
+        with:
+          repository: aincraft-org/mint
+          ref: 873fd3e359d3f3ac5b22fc84bc9aaae2a6adabdd
+          path: mint
+          fetch-depth: 1
+          token: ${{ secrets.MINT_REPO_TOKEN }}
+
+      - name: Link mint local Maven repository
+        run: ln -s "$GITHUB_WORKSPACE/mint" "$GITHUB_WORKSPACE/../mint"
+
+      - name: Publish mint API to local Maven repository
+        working-directory: mint
+        run: |
+          chmod +x gradlew
+          ./gradlew \
+            :api:publishMavenPublicationToLocalBuildRepository \
+            --console=plain --no-daemon
+
+      - name: Checkout Preferences API dependency
+        uses: actions/checkout@v4
+        with:
+          repository: mintychochip/Preferences
+          ref: c78eac8c81104ba0890fc98d5f49090d90d0dee7
+          path: preferences
+          fetch-depth: 1
+
+      - name: Publish Preferences API to isolated Maven local
+        working-directory: preferences
+        run: |
+          chmod +x gradlew
+          ./gradlew :api:publishToMavenLocal \
+            -Dmaven.repo.local=${{ runner.temp }}/m2 \
+            --console=plain --no-daemon
+
+      - name: Verify required local dependency artifacts
+        run: |
+          test -f ../craftux/build/maven-repo/dev/craftux/craftux-paper/1.0.2/craftux-paper-1.0.2.pom
+          test -f ../mint/build/maven-repo/dev/jlo/mint/mint-api/1.0.0/mint-api-1.0.0.pom
+          test -f "${{ runner.temp }}/m2/dev/jlo/preferences-api/0.1.0/preferences-api-0.1.0.pom"
+
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
@@ -66,10 +147,10 @@ jobs:
 
       - name: Check (compile + Error Prone + unit tests + static analysis)
         # quality.fail not set → Checkstyle/PMD/SpotBugs report-only
-        run: ./gradlew check --console=plain --no-daemon
+        run: ./gradlew check -Dmaven.repo.local=${{ runner.temp }}/m2 --console=plain --no-daemon
 
       - name: Shadow jar
-        run: ./gradlew :paper:shadowJar --console=plain --no-daemon
+        run: ./gradlew :paper:shadowJar -Dmaven.repo.local=${{ runner.temp }}/m2 --console=plain --no-daemon
 
       - name: Upload paper shadow jar
         uses: actions/upload-artifact@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- **Profession-gated block breaking**: `block-break-gates` in `config.yml` restricts breaking a material to players at/above a configured profession level (bypass: `modularjobs.bypassblockbreak`).
+
 ### Breaking
 
 - **Module layout rename**: Gradle modules and tree paths are now `api` / `common` / `paper` / `web` (was `jobs-api`, `jobs-core`, `jobs-web`, `jobs-session-api`).

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ economy:
 | `jobs.command.admin.archive` | op | Others' archive |
 | `jobs.command.leaveall` | true | Leave all jobs |
 | `jobs.command.admin.treeeditor` | op | Upgrade tree editor |
+| `modularjobs.bypassblockbreak` | op | Bypass profession-gated block breaking |
 
 Admin commands (`/jobs boost`, `/jobs editor`, `/jobs applyedits`) require `modularjobs.admin`.
 
@@ -132,6 +133,17 @@ profession-apis:
 ```
 
 Set `true` only when integrating consumers that expect `ProfessionService` / related APIs. Station/NodeHarvest may still be stubs.
+
+### Block breaking gates
+
+Restrict breaking a material to a minimum profession level (`block-break-gates` in `config.yml`):
+
+```yaml
+block-break-gates:
+  diamond_ore: { profession: mining, level: 30 }
+```
+
+Players below the level cannot break the block; the event is cancelled with a message. Staff bypass via `modularjobs.bypassblockbreak`.
 
 ### Soft depends
 

--- a/api/src/main/java/net/aincraft/profession/BlockBreakGate.java
+++ b/api/src/main/java/net/aincraft/profession/BlockBreakGate.java
@@ -1,0 +1,23 @@
+package net.aincraft.profession;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * One profession→material level gate: breaking the material requires at least
+ * {@code minLevel} in {@code professionId} (a §8.1 catalog id).
+ *
+ * @param materialKey lowercase Minecraft material key, e.g. {@code diamond_ore}
+ * @param professionId canonical profession id, e.g. {@code mining}
+ * @param minLevel     minimum profession level required to break
+ */
+public record BlockBreakGate(
+    @NotNull String materialKey,
+    @NotNull String professionId,
+    int minLevel
+) {
+
+  public BlockBreakGate {
+    materialKey = materialKey.toLowerCase();
+    professionId = professionId.toLowerCase();
+  }
+}

--- a/api/src/main/java/net/aincraft/service/BlockBreakGateService.java
+++ b/api/src/main/java/net/aincraft/service/BlockBreakGateService.java
@@ -1,0 +1,20 @@
+package net.aincraft.service;
+
+import java.util.List;
+import java.util.Optional;
+import net.aincraft.profession.BlockBreakGate;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Read-only access to the configured profession→material block-break gates.
+ */
+public interface BlockBreakGateService {
+
+  /** All configured gates, catalog-irrelevant order. */
+  @NotNull
+  List<BlockBreakGate> gates();
+
+  /** Gate for a material key (case-insensitive), or empty if not gated. */
+  @NotNull
+  Optional<BlockBreakGate> gateFor(@NotNull String materialKey);
+}

--- a/api/src/test/java/net/aincraft/profession/BlockBreakGateTest.java
+++ b/api/src/test/java/net/aincraft/profession/BlockBreakGateTest.java
@@ -1,0 +1,43 @@
+package net.aincraft.profession;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Optional;
+import net.aincraft.service.BlockBreakGateService;
+import org.junit.jupiter.api.Test;
+
+class BlockBreakGateTest {
+
+  private record FixedService(List<BlockBreakGate> gates) implements BlockBreakGateService {
+    @Override
+    public List<BlockBreakGate> gates() {
+      return gates;
+    }
+
+    @Override
+    public Optional<BlockBreakGate> gateFor(String materialKey) {
+      return gates.stream()
+          .filter(g -> g.materialKey().equalsIgnoreCase(materialKey))
+          .findFirst();
+    }
+  }
+
+  @Test
+  void recordNormalizesCase() {
+    BlockBreakGate gate = new BlockBreakGate("Diamond_Ore", "Mining", 30);
+    assertEquals("diamond_ore", gate.materialKey());
+    assertEquals("mining", gate.professionId());
+    assertEquals(30, gate.minLevel());
+  }
+
+  @Test
+  void serviceFindsGateCaseInsensitively() {
+    BlockBreakGateService svc = new FixedService(
+        List.of(new BlockBreakGate("diamond_ore", "mining", 30)));
+    assertTrue(svc.gateFor("DIAMOND_ORE").isPresent());
+    assertEquals(30, svc.gateFor("diamond_ore").orElseThrow().minLevel());
+    assertTrue(svc.gateFor("stone").isEmpty());
+  }
+}

--- a/docs/superpowers/plans/2026-08-07-profession-block-break-gates.md
+++ b/docs/superpowers/plans/2026-08-07-profession-block-break-gates.md
@@ -1,0 +1,799 @@
+# Profession-Gated Block Breaking Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Block breaking is restricted by profession level via per-material config (`block-break-gates` in `config.yml`): a player below the required profession level cannot break the block (event cancelled + themed message), with an op-default bypass permission.
+
+**Architecture:** A new `api`-level `BlockBreakGate` record (material key as `String`, profession id, min level) + `BlockBreakGateService`. In `paper`, a `YamlBlockBreakGateLoader` parses the config section into a cached `BlockBreakGateStore`, and a `BlockBreakGateListener` at `EventPriority.NORMAL` (before the `MONITOR` pay listener) looks up the gate for the broken material, checks `ProfessionService.level(player, professionId)`, and cancels + messages when below. Wired into `PluginContext` so the listener joins `created.listeners`.
+
+**Tech Stack:** Java 21/25, PaperMC API (Bukkit `Material`, `BlockBreakEvent`, `Player`), MockBukkit 26.2 for listeners, JUnit 5 (Jupiter), Gradle Kotlin DSL, project's own `config.yml`/`YamlConfiguration` + `Messages` MiniMessage.
+
+## Global Constraints
+
+- `api` module is **pure** — no Bukkit/Paper imports allowed (`api/build.gradle.kts` deps: `common`, `adventure.api`, `jetbrains.annotations`). `Material` must NOT appear in `api`; use `String materialKey`.
+- Java 21 language features OK (records, pattern matching, `switch` arrows, `List.of`); project uses `@NotNull`/`@Nullable` (`org.jetbrains.annotations`) in `api`, `@NullMarked` (`org.jspecify`) in `paper`.
+- Gate key: profession id from the §8.1 catalog (`ProfessionCatalog.resolve`) — resolve the profession at load time; invalid → `logger.warning`, skip entry. Same for unknown `Material.matchMaterial(key)` and `level <= 0`.
+- `level` parse: `config.isInt("level")`; if not an int → warn + skip.
+- Material → `org.bukkit.Material.matchMaterial(String)`; missing/`AIR` → warn + skip.
+- Empty/missing section → empty store; listener short-circuits; no behavior change.
+- Bypass: `player.hasPermission("modularjobs.bypassblockbreak")`.
+- Message: `Messages.send(player, "<error>... <primary>... <primary>... <secondary>...")` format — exact template in Task 3.
+- Event priority: `EventPriority.NORMAL`, `ignoreCancelled = true`.
+- An unjoined profession (`ProfessionService.level(...)` returns `OptionalInt.empty()`) is treated as level 0 → block.
+- Tests: JUnit 5 (`org.junit.jupiter`), MockBukkit via `net.aincraft.test.MockBukkitSupport`; `@AfterEach MockBukkitSupport.unmockServer()`. No checkstyle/spotbugs gates per plan; project formatter/checkstyle runs once in Task 4.
+- No shared mutable global state: store is immutable after load; listener stateless.
+- Docs/changelog updated in Task 4 (`docs/database-schema.md` NOT touched — schema unchanged; update `CHANGELOG.md` and `README.md` only if they enumerate features — see Task 4).
+
+---
+
+### Task 1: api — `BlockBreakGate` record + `BlockBreakGateService`
+
+**Files:**
+- Create: `api/src/main/java/net/aincraft/profession/BlockBreakGate.java`
+- Create: `api/src/main/java/net/aincraft/service/BlockBreakGateService.java`
+- Test: `api/src/test/java/net/aincraft/profession/BlockBreakGateTest.java`
+
+**Interfaces:**
+- Produces:
+  - `record BlockBreakGate(@NotNull String materialKey, @NotNull String professionId, int minLevel)` — compact constructor lowercases `materialKey` and `professionId`; `minLevel` stored as-is.
+  - `interface BlockBreakGateService { @NotNull List<BlockBreakGate> gates(); @NotNull Optional<BlockBreakGate> gateFor(@NotNull String materialKey); }` — `gateFor` matches `materialKey.equalsIgnoreCase(...)`.
+
+- [ ] **Step 1: Write the failing test**
+
+`api/src/test/java/net/aincraft/profession/BlockBreakGateTest.java`:
+
+```java
+package net.aincraft.profession;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Optional;
+import net.aincraft.service.BlockBreakGateService;
+import org.junit.jupiter.api.Test;
+
+class BlockBreakGateTest {
+
+  private record FixedService(List<BlockBreakGate> gates) implements BlockBreakGateService {
+    @Override
+    public List<BlockBreakGate> gates() {
+      return gates;
+    }
+
+    @Override
+    public Optional<BlockBreakGate> gateFor(String materialKey) {
+      return gates.stream()
+          .filter(g -> g.materialKey().equalsIgnoreCase(materialKey))
+          .findFirst();
+    }
+  }
+
+  @Test
+  void recordNormalizesCase() {
+    BlockBreakGate gate = new BlockBreakGate("Diamond_Ore", "Mining", 30);
+    assertEquals("diamond_ore", gate.materialKey());
+    assertEquals("mining", gate.professionId());
+    assertEquals(30, gate.minLevel());
+  }
+
+  @Test
+  void serviceFindsGateCaseInsensitively() {
+    BlockBreakGateService svc = new FixedService(
+        List.of(new BlockBreakGate("diamond_ore", "mining", 30)));
+    assertTrue(svc.gateFor("DIAMOND_ORE").isPresent());
+    assertEquals(30, svc.gateFor("diamond_ore").orElseThrow().minLevel());
+    assertTrue(svc.gateFor("stone").isEmpty());
+  }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :api:test --tests net.aincraft.profession.BlockBreakGateTest -v`
+Expected: FAIL — compilation error: `cannot find symbol` for `BlockBreakGate` / `BlockBreakGateService`.
+
+- [ ] **Step 3: Write the api production code**
+
+`api/src/main/java/net/aincraft/profession/BlockBreakGate.java`:
+
+```java
+package net.aincraft.profession;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * One profession→material level gate: breaking the material requires at least
+ * {@code minLevel} in {@code professionId} (a §8.1 catalog id).
+ *
+ * @param materialKey lowercase Minecraft material key, e.g. {@code diamond_ore}
+ * @param professionId canonical profession id, e.g. {@code mining}
+ * @param minLevel     minimum profession level required to break
+ */
+public record BlockBreakGate(
+    @NotNull String materialKey,
+    @NotNull String professionId,
+    int minLevel
+) {
+
+  public BlockBreakGate {
+    materialKey = materialKey.toLowerCase();
+    professionId = professionId.toLowerCase();
+  }
+}
+```
+
+`api/src/main/java/net/aincraft/service/BlockBreakGateService.java`:
+
+```java
+package net.aincraft.service;
+
+import java.util.List;
+import java.util.Optional;
+import net.aincraft.profession.BlockBreakGate;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Read-only access to the configured profession→material block-break gates.
+ */
+public interface BlockBreakGateService {
+
+  /** All configured gates, catalog-irrelevant order. */
+  @NotNull
+  List<BlockBreakGate> gates();
+
+  /** Gate for a material key (case-insensitive), or empty if not gated. */
+  @NotNull
+  Optional<BlockBreakGate> gateFor(@NotNull String materialKey);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./gradlew :api:test --tests net.aincraft.profession.BlockBreakGateTest -v`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add api/src/main/java/net/aincraft/profession/BlockBreakGate.java \
+        api/src/main/java/net/aincraft/service/BlockBreakGateService.java \
+        api/src/test/java/net/aincraft/profession/BlockBreakGateTest.java
+git commit -m "feat(api): block break gate model and service contract"
+```
+
+---
+
+### Task 2: paper — `YamlBlockBreakGateLoader` + `BlockBreakGateStore`
+
+**Files:**
+- Create: `paper/src/main/java/net/aincraft/profession/YamlBlockBreakGateLoader.java`
+- Create: `paper/src/main/java/net/aincraft/profession/BlockBreakGateStore.java`
+- Test: `paper/src/test/java/net/aincraft/profession/YamlBlockBreakGateLoaderTest.java`
+
+**Interfaces:**
+- Consumes: `BlockBreakGate`, `BlockBreakGateService` (Task 1); `net.aincraft.config.YamlConfiguration` (exists); `ProfessionCatalog.resolve(String)` (exists); `org.bukkit.Material.matchMaterial(String)` (exists); `org.bukkit.plugin.Plugin.getLogger()`.
+- Produces:
+  - `final class BlockBreakGateStore implements BlockBreakGateService` — ctor `BlockBreakGateStore(List<BlockBreakGate> gates)`; stores `Map<String, BlockBreakGate>` by lowercased material key; `gateFor` delegates to map lookup; `gates()` returns immutable list. `isEmpty()` returns `gates.isEmpty()`.
+  - `final class YamlBlockBreakGateLoader` — ctor `YamlBlockBreakGateLoader(Plugin plugin)`; method `List<BlockBreakGate> load(YamlConfiguration config)`; reads section `block-break-gates` (or empty list if `config.getConfigurationSection("block-break-gates") == null`); for each key: skip `configuration`-type keys (`config.isConfigurationSection(key)`); validate material/profession/level per Global Constraints; `logger.warning(...)` + skip on any invalid.
+
+- [ ] **Step 1: Write the failing test**
+
+`paper/src/test/java/net/aincraft/profession/YamlBlockBreakGateLoaderTest.java`:
+
+```java
+package net.aincraft.profession;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.logging.Logger;
+import net.aincraft.test.MockBukkitSupport;
+import org.bukkit.Material;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.MemorySection;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class YamlBlockBreakGateLoaderTest {
+
+  private YamlBlockBreakGateLoader loader;
+
+  @BeforeEach
+  void setUp() {
+    MockBukkitSupport.mockServer();
+    loader = new YamlBlockBreakGateLoader(Logger.getLogger("test"));
+  }
+
+  @AfterEach
+  void tearDown() {
+    MockBukkitSupport.unmockServer();
+  }
+
+  @Test
+  void parsesValidGateEntries() {
+    YamlConfiguration config = new YamlConfiguration();
+    config.set("block-break-gates.diamond_ore.profession", "mining");
+    config.set("block-break-gates.diamond_ore.level", 30);
+    config.set("block-break-gates.ancient_debris.profession", "mining");
+    config.set("block-break-gates.ancient_debris.level", 40);
+
+    List<BlockBreakGate> gates = loader.load(config);
+
+    assertEquals(2, gates.size());
+    BlockBreakGate diamond = gates.stream()
+        .filter(g -> g.materialKey().equals("diamond_ore"))
+        .findFirst().orElseThrow();
+    assertEquals("mining", diamond.professionId());
+    assertEquals(30, diamond.minLevel());
+    assertTrue(Material.matchMaterial(diamond.materialKey()) != null);
+  }
+
+  @Test
+  void skipsInvalidEntriesWithWarnings() {
+    YamlConfiguration config = new YamlConfiguration();
+    // Unknown material
+    config.set("block-break-gates.not_a_real_material.profession", "mining");
+    config.set("block-break-gates.not_a_real_material.level", 30);
+    // Unknown profession
+    config.set("block-break-gates.stone.profession", "not_a_profession");
+    config.set("block-break-gates.stone.level", 5);
+    // Non-int level
+    config.set("block-break-gates.dirt.profession", "farming");
+    config.set("block-break-gates.dirt.level", "high");
+    // Zero/negative level
+    config.set("block-break-gates.sand.profession", "mining");
+    config.set("block-break-gates.sand.level", 0);
+
+    List<BlockBreakGate> gates = loader.load(config);
+    assertTrue(gates.isEmpty());
+  }
+
+  @Test
+  void emptyOrMissingSectionYieldsEmptyList() {
+    YamlConfiguration empty = new YamlConfiguration();
+    assertTrue(loader.load(empty).isEmpty());
+  }
+
+  @Test
+  void storeLooksUpCaseInsensitively() {
+    BlockBreakGateStore store = new BlockBreakGateStore(
+        List.of(new BlockBreakGate("diamond_ore", "mining", 30)));
+    assertTrue(store.gateFor("DIAMOND_ORE").isPresent());
+    assertTrue(store.gateFor("stone").isEmpty());
+    assertFalse(store.isEmpty());
+    assertTrue(new BlockBreakGateStore(List.of()).isEmpty());
+  }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :paper:test --tests net.aincraft.profession.YamlBlockBreakGateLoaderTest -v`
+Expected: FAIL — `cannot find symbol` for `YamlBlockBreakGateLoader` / `BlockBreakGateStore`.
+
+- [ ] **Step 3: Write the loader + store**
+
+`paper/src/main/java/net/aincraft/profession/BlockBreakGateStore.java`:
+
+```java
+package net.aincraft.profession;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import net.aincraft.service.BlockBreakGateService;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Immutable in-memory gate table keyed by lowercase material key.
+ */
+public final class BlockBreakGateStore implements BlockBreakGateService {
+
+  private final Map<String, BlockBreakGate> byMaterial;
+
+  public BlockBreakGateStore(@NotNull List<BlockBreakGate> gates) {
+    Map<String, BlockBreakGate> map = gates.stream()
+        .collect(Collectors.toUnmodifiableMap(
+            g -> g.materialKey().toLowerCase(Locale.ROOT), g -> g));
+    this.byMaterial = Map.copyOf(map);
+  }
+
+  public boolean isEmpty() {
+    return byMaterial.isEmpty();
+  }
+
+  @Override
+  public @NotNull List<BlockBreakGate> gates() {
+    return List.copyOf(byMaterial.values());
+  }
+
+  @Override
+  public @NotNull Optional<BlockBreakGate> gateFor(@NotNull String materialKey) {
+    return Optional.ofNullable(byMaterial.get(materialKey.toLowerCase(Locale.ROOT)));
+  }
+}
+```
+
+`paper/src/main/java/net/aincraft/profession/YamlBlockBreakGateLoader.java`:
+
+```java
+package net.aincraft.profession;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.logging.Logger;
+import net.aincraft.config.YamlConfiguration;
+import org.bukkit.Material;
+import org.bukkit.configuration.ConfigurationSection;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Parses the {@code block-break-gates} section of config.yml into {@link BlockBreakGate}s.
+ * Invalid entries (unknown material/profession, non-positive level) are skipped
+ * with a warning; a missing section yields an empty list.
+ */
+public final class YamlBlockBreakGateLoader {
+
+  private static final String SECTION = "block-break-gates";
+
+  private final Logger logger;
+
+  public YamlBlockBreakGateLoader(@NotNull Logger logger) {
+    this.logger = logger;
+  }
+
+  public @NotNull List<BlockBreakGate> load(@NotNull YamlConfiguration config) {
+    ConfigurationSection section = config.getConfigurationSection(SECTION);
+    if (section == null) {
+      return List.of();
+    }
+    List<BlockBreakGate> gates = new ArrayList<>();
+    for (String materialKey : section.getKeys(false)) {
+      if (section.isConfigurationSection(materialKey)) {
+        parseEntry(section.getConfigurationSection(materialKey), materialKey).ifPresent(gates::add);
+      }
+    }
+    return gates;
+  }
+
+  private java.util.Optional<BlockBreakGate> parseEntry(
+      ConfigurationSection entry, String materialKey) {
+    Material material = Material.matchMaterial(materialKey);
+    if (material == null || material == Material.AIR) {
+      logger.warning("block-break-gates: unknown material '" + materialKey + "' — skipping");
+      return java.util.Optional.empty();
+    }
+    String professionId = entry.getString("profession");
+    if (professionId == null
+        || !ProfessionCatalog.resolve(professionId).isPresent()) {
+      logger.warning("block-break-gates: '" + materialKey + "' has unknown profession '"
+          + professionId + "' — skipping");
+      return java.util.Optional.empty();
+    }
+    if (!entry.isInt("level")) {
+      logger.warning("block-break-gates: '" + materialKey + "' level must be an int — skipping");
+      return java.util.Optional.empty();
+    }
+    int level = entry.getInt("level");
+    if (level <= 0) {
+      logger.warning("block-break-gates: '" + materialKey + "' level must be > 0 — skipping");
+      return java.util.Optional.empty();
+    }
+    String canonical = ProfessionCatalog.resolve(professionId).orElseThrow().id().toLowerCase(Locale.ROOT);
+    return java.util.Optional.of(
+        new BlockBreakGate(materialKey.toLowerCase(Locale.ROOT), canonical, level));
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./gradlew :paper:test --tests net.aincraft.profession.YamlBlockBreakGateLoaderTest -v`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add paper/src/main/java/net/aincraft/profession/YamlBlockBreakGateLoader.java \
+        paper/src/main/java/net/aincraft/profession/BlockBreakGateStore.java \
+        paper/src/test/java/net/aincraft/profession/YamlBlockBreakGateLoaderTest.java
+git commit -m "feat(paper): parse and store block break gates from config"
+```
+
+---
+
+### Task 3: paper — `BlockBreakGateListener`
+
+**Files:**
+- Create: `paper/src/main/java/net/aincraft/profession/BlockBreakGateListener.java`
+- Test: `paper/src/test/java/net/aincraft/profession/BlockBreakGateListenerTest.java`
+
+**Interfaces:**
+- Consumes: `BlockBreakGateStore` (Task 2), `net.aincraft.service.ProfessionService` (exists), `org.bukkit.block.Block`/`Player`/`BlockBreakEvent` (Bukkit), `Messages` (exists).
+- Produces:
+  - `final class BlockBreakGateListener implements Listener` — ctor `BlockBreakGateListener(BlockBreakGateStore store, ProfessionService professionService)`; public method `void onBlockBreak(BlockBreakEvent event)` annotated `@EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)`.
+  - `static final String BYPASS_PERMISSION = "modularjobs.bypassblockbreak"`.
+  - Behavior: player `hasPermission(BYPASS_PERMISSION)` → return. `store.gateFor(block.getType().name().toLowerCase(Locale.ROOT))` empty → return. `professionService.level(player.getUniqueId(), gate.professionId())` empty or `< gate.minLevel()` → `event.setCancelled(true)` + `Messages.send(player, gateMessage(gate))`.
+  - `gateMessage`: `"<error>Level <primary>" + gate.minLevel() + " <error>" + gate.professionId() + " required to break <secondary>" + gate.materialKey() + "</secondary>"`.
+  - Material key: `block.getType().name().toLowerCase(Locale.ROOT)` — `Material.toString()` yields the SCREAMING_SNAKE name (`DIAMOND_ORE`), matching how `matchMaterial(key)` parses from config. No `Key`/namespaced resolution needed (config keys are un-namespaced keys).
+
+- [ ] **Step 1: Write the failing test**
+
+`paper/src/test/java/net/aincraft/profession/BlockBreakGateListenerTest.java`:
+
+```java
+package net.aincraft.profession;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.UUID;
+import net.aincraft.service.ProfessionService;
+import net.aincraft.test.MockBukkitSupport;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class BlockBreakGateListenerTest {
+
+  private static final String BYPASS = "modularjobs.bypassblockbreak";
+
+  private StubProfessionService professions;
+
+  private record StubProfessionService(
+      java.util.Map<String, OptionalInt> levels) implements ProfessionService {
+
+    @Override
+    public List<net.aincraft.profession.ProfessionDefinition> tracks() {
+      return List.of();
+    }
+
+    @Override
+    public Optional<net.aincraft.profession.ProfessionDefinition> resolve(String idOrAlias) {
+      return net.aincraft.profession.ProfessionCatalog.resolve(idOrAlias);
+    }
+
+    @Override
+    public OptionalInt level(UUID playerId, String professionIdOrAlias) {
+      return levels.getOrDefault(professionIdOrAlias, OptionalInt.empty());
+    }
+
+    @Override
+    public Optional<java.math.BigDecimal> experience(UUID playerId, String professionIdOrAlias) {
+      return Optional.empty();
+    }
+
+    @Override
+    public boolean ensureTrack(UUID playerId, String professionIdOrAlias) {
+      return true;
+    }
+  }
+
+  private BlockBreakGateListener listener;
+  private Player player;
+
+  @BeforeEach
+  void setUp() {
+    MockBukkitSupport.mockServer();
+    professions = new StubProfessionService(new java.util.HashMap<>());
+    BlockBreakGateStore store = new BlockBreakGateStore(List.of(
+        new BlockBreakGate("diamond_ore", "mining", 30)));
+    listener = new BlockBreakGateListener(store, professions);
+    player = MockBukkitSupport.mockServer().addPlayer();
+  }
+
+  @AfterEach
+  void tearDown() {
+    MockBukkitSupport.unmockServer();
+  }
+
+  @Test
+  void belowRequiredLevelCancelsBreak() {
+    professions.levels().put("mining", OptionalInt.of(29));
+    assertTrue(breakEvent().isCancelled());
+  }
+
+  @Test
+  void atRequiredLevelAllowsBreak() {
+    professions.levels().put("mining", OptionalInt.of(30));
+    assertFalse(breakEvent().isCancelled());
+  }
+
+  @Test
+  void aboveRequiredLevelAllowsBreak() {
+    professions.levels().put("mining", OptionalInt.of(45));
+    assertFalse(breakEvent().isCancelled());
+  }
+
+  @Test
+  void unjoinedProfessionCancelsBreak() {
+    // no level entry -> OptionalInt.empty -> treated as level 0
+    assertTrue(breakEvent().isCancelled());
+  }
+
+  @Test
+  void ungatedMaterialAllowsBreak() {
+    Block block = mockBlock(Material.STONE);
+    BlockBreakEvent event = new BlockBreakEvent(block, player);
+    listener.onBlockBreak(event);
+    assertFalse(event.isCancelled());
+  }
+
+  @Test
+  void bypassPermissionAllowsBreak() {
+    professions.levels().put("mining", OptionalInt.of(1));
+    player.addAttachment(MockBukkitSupport.mockServer().getPluginManager().getPlugin("MockBukkit"))
+        .setPermission(BYPASS, true);
+    assertFalse(breakEvent().isCancelled());
+  }
+
+  private BlockBreakEvent breakEvent() {
+    Block block = mockBlock(Material.DIAMOND_ORE);
+    BlockBreakEvent event = new BlockBreakEvent(block, player);
+    listener.onBlockBreak(event);
+    return event;
+  }
+
+  private Block mockBlock(Material material) {
+    var server = org.bukkit.Bukkit.getServer();
+    org.bukkit.World world = server.getWorlds().isEmpty()
+        ? server.createWorld(new org.bukkit.WorldCreator("world"))
+        : server.getWorlds().getFirst();
+    Block block = world.getBlockAt(0, 64, 0);
+    block.setType(material);
+    return block;
+  }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :paper:test --tests net.aincraft.profession.BlockBreakGateListenerTest -v`
+Expected: FAIL — `cannot find symbol` for `BlockBreakGateListener`.
+
+- [ ] **Step 3: Write the listener**
+
+`paper/src/main/java/net/aincraft/profession/BlockBreakGateListener.java`:
+
+```java
+package net.aincraft.profession;
+
+import java.util.Locale;
+import java.util.OptionalInt;
+import net.aincraft.service.ProfessionService;
+import net.aincraft.util.Messages;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Cancels breaking a material whose configured profession level requirement is unmet.
+ *
+ * <p>Runs at {@link EventPriority#NORMAL} so a cancelled break happens before the
+ * {@code MONITOR} payment listener, keeping denied breaks out of pay/exploit logic.
+ */
+public final class BlockBreakGateListener implements Listener {
+
+  public static final String BYPASS_PERMISSION = "modularjobs.bypassblockbreak";
+
+  private final BlockBreakGateStore store;
+  private final ProfessionService professionService;
+
+  public BlockBreakGateListener(
+      @NotNull BlockBreakGateStore store,
+      @NotNull ProfessionService professionService) {
+    this.store = store;
+    this.professionService = professionService;
+  }
+
+  @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
+  public void onBlockBreak(final BlockBreakEvent event) {
+    Player player = event.getPlayer();
+    if (player.hasPermission(BYPASS_PERMISSION)) {
+      return;
+    }
+    String materialKey = event.getBlock().getType().name().toLowerCase(Locale.ROOT);
+    BlockBreakGate gate = store.gateFor(materialKey).orElse(null);
+    if (gate == null) {
+      return;
+    }
+    OptionalInt level = professionService.level(player.getUniqueId(), gate.professionId());
+    if (level.isEmpty() || level.getAsInt() < gate.minLevel()) {
+      event.setCancelled(true);
+      Messages.send(player, gateMessage(gate));
+    }
+  }
+
+  private static String gateMessage(BlockBreakGate gate) {
+    return "<error>Level <primary>" + gate.minLevel()
+        + " <error>" + gate.professionId()
+        + " required to break <secondary>" + gate.materialKey() + "</secondary>";
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./gradlew :paper:test --tests net.aincraft.profession.BlockBreakGateListenerTest -v`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add paper/src/main/java/net/aincraft/profession/BlockBreakGateListener.java \
+        paper/src/test/java/net/aincraft/profession/BlockBreakGateListenerTest.java
+git commit -m "feat(paper): cancel block breaks below profession level gate"
+```
+
+---
+
+### Task 4: paper — wire into `PluginContext`, config.yml sample, plugin.yml permission
+
+**Files:**
+- Modify: `paper/src/main/java/net/aincraft/PluginContext.java` (composition root)
+- Modify: `paper/src/main/resources/config.yml` (add commented sample section)
+- Modify: `paper/src/main/resources/plugin.yml` (add bypass permission)
+- Test: `paper/src/test/java/net/aincraft/PluginYmlProductionReadinessTest.java` — extend if the test asserts the full plugin.yml permission set; otherwise no test change. Inspect the existing test first (Step 3).
+
+**Interfaces:**
+- Consumes: `YamlBlockBreakGateLoader`, `BlockBreakGateStore`, `BlockBreakGateListener` (Tasks 2-3), `PluginContext.createInto(...)` pattern.
+- Produces: `BlockBreakGateListener` added to `listenerList` inside `createInto`, constructed with `new BlockBreakGateStore(new YamlBlockBreakGateLoader(plugin.getLogger()).load(databaseConfig))`.
+
+- [ ] **Step 1: Wire the gate into the composition root**
+
+In `PluginContext.createInto(JavaPlugin plugin, PluginResources resources)`, immediately after the existing `ProfessionWiring professions = ProfessionWiring.create(domain.jobService);` line, add:
+
+```java
+    BlockBreakGateStore blockBreakGateStore = new BlockBreakGateStore(
+        new YamlBlockBreakGateLoader(plugin.getLogger()).load(databaseConfig));
+```
+
+and, in the `List<Listener> listenerList = new ArrayList<>();` block (after the existing `listenerList.add(new UpgradePermissionRestoreListener(...))` line), add:
+
+```java
+    listenerList.add(new BlockBreakGateListener(blockBreakGateStore, professions.professionService));
+```
+
+Add the three imports at the top of the file:
+
+```java
+import net.aincraft.profession.BlockBreakGateListener;
+import net.aincraft.profession.BlockBreakGateStore;
+import net.aincraft.profession.YamlBlockBreakGateLoader;
+```
+
+- [ ] **Step 2: Add config.yml sample + plugin.yml permission**
+
+In `paper/src/main/resources/config.yml`, after the `profession-apis` block, append:
+
+```yaml
+# Block breaking gates: minimum profession level required to break a material.
+# Material names are Minecraft keys (diamond_ore, ancient_debris, ...).
+# Professions are §8.1 catalog ids (mining, woodcutting, farming, ...).
+block-break-gates:
+  # diamond_ore: { profession: mining, level: 30 }
+  # deepslate_diamond_ore: { profession: mining, level: 30 }
+```
+
+In `paper/src/main/resources/plugin.yml`, append under the `permissions:` map:
+
+```yaml
+  modularjobs.bypassblockbreak:
+    description: Bypass profession-gated block breaking
+    default: op
+```
+
+- [ ] **Step 3: Verify PluginYmlProductionReadinessTest still passes**
+
+Run: `./gradlew :paper:test --tests net.aincraft.PluginYmlProductionReadinessTest -v`
+Expected: PASS. If it fails because the test asserts an exact permission list, update the test to include `modularjobs.bypassblockbreak` in the expected set (read the test first).
+
+- [ ] **Step 4: Run full paper + api test suites**
+
+Run: `./gradlew :api:test :common:test :paper:test`
+Expected: ALL PASS (including the 2 api + 10 paper new tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add paper/src/main/java/net/aincraft/PluginContext.java \
+        paper/src/main/resources/config.yml \
+        paper/src/main/resources/plugin.yml \
+        paper/src/test/java/net/aincraft/PluginYmlProductionReadinessTest.java
+git commit -m "feat(paper): wire block break gates into plugin context"
+```
+
+---
+
+### Task 5: docs + changelog
+
+**Files:**
+- Modify: `CHANGELOG.md`
+- Modify: `README.md` (only if it enumerates features — inspect first; if it does, add a one-line mention under the feature list)
+
+**Interfaces:**
+- Consumes: feature naming from the spec (`block-break-gates`, `modularjobs.bypassblockbreak`).
+
+- [ ] **Step 1: Inspect CHANGELOG.md and README.md**
+
+Run: `read CHANGELOG.md` and `read README.md`.
+Check: does README.md list features/config? Does CHANGELOG.md have an Unreleased section?
+
+- [ ] **Step 2: Add changelog entry**
+
+In `CHANGELOG.md` top, under the latest version (or create an `## Unreleased` section if none), add:
+
+```markdown
+### Added
+- Profession-gated block breaking: `block-break-gates` in config.yml restricts
+  breaking a material to players at/above a configured profession level
+  (bypass: `modularjobs.bypassblockbreak`).
+```
+
+- [ ] **Step 3: Add README feature mention (only if Step 1 shows a feature list)**
+
+Add one line under the closest feature grouping in `README.md`:
+
+```markdown
+- Profession-gated block breaking (per-material level requirements in `config.yml`)
+```
+
+- [ ] **Step 4: Final verification**
+
+Run: `./gradlew :api:test :common:test :paper:test`
+Expected: ALL PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add CHANGELOG.md README.md
+git commit -m "docs: changelog and README for block break gates"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Hard gate cancel + message → Task 3 listener.
+- Check on break attempt (`BlockBreakEvent`) → Task 3.
+- Per-material explicit `{profession, level}` config → Task 2 loader + Task 4 sample.
+- Explicit profession id, decoupled from paying job → Task 2 (canonical id via `ProfessionCatalog.resolve`), Task 3 (gate stores profession id, checks `ProfessionService.level`).
+- Message with reason → Task 3 `gateMessage`.
+- Bypass permission `modularjobs.bypassblockbreak`, op default → Task 3 + Task 4 plugin.yml.
+- Block all breaking outright → Task 3 (cancel).
+- Bad config warn+skip; empty section = off → Task 2 (`skipsInvalidEntriesWithWarnings`, `emptyOrMissingSectionYieldsEmptyList`) + loader warnings.
+- Fear of `MONITOR`-priority pay listener interaction → addressed: gate at `NORMAL` (spec §"Priority ordering"; Task 3 javadoc).
+- No schema change → docs/database-schema.md untouched (explicit non-goal).
+- Error handling: unjoined profession = level 0 → Task 3 `unjoinedProfessionCancelsBreak`.
+
+**Placeholder scan:** No TBD/TODO/"similar to"/"add appropriate handling". Every step has concrete code/commands. The only conditional is Task 4 Step 3 and Task 5 Steps 1-3, which instruct to inspect first and give exact fallback code.
+
+**Type consistency:**
+- `BlockBreakGate` ctor/prod fields: `materialKey` (String), `professionId` (String), `minLevel` (int) — consistent across Tasks 1-3 and tests.
+- `BlockBreakGateService.gateFor(String)` returns `Optional<BlockBreakGate>`; `BlockBreakGateStore` implements it — consistent.
+- `BlockBreakGateStore` ctor takes `List<BlockBreakGate>`; `isEmpty()` exists — used in listener tests only via `gateFor`; used in wiring (Task 4) via no method requiring `isEmpty`.
+- `YamlBlockBreakGateLoader.load(YamlConfiguration)` — Task 2 defines; Task 4 consumes with `databaseConfig` (which is `net.aincraft.config.YamlConfiguration`). Note: `createInto`'s `databaseConfig` is `YamlConfiguration` (the paper wrapper) — correct type.
+- `BlockBreakGateListener(BLOCK_BREAK_GATE_STORE, ProfessionService)` ctor and `BYPASS_PERMISSION` constant — Task 3 defines, Task 4 consumes `professions.professionService` (exists, `ProfessionService`).
+- Loader test ctor `YamlBlockBreakGateLoader(Logger.getLogger("test"))` matches the `Logger` ctor in Task 2 Step 3 — consistent (test passes a `Logger`; production passes `plugin.getLogger()`).
+- Material key normalization: store lowercases; listener lowercases `Material.name()`; config keys lowercased in loader — all `Locale.ROOT`, consistent.
+
+**Scope:** Single-feature plan sized for one implementation pass. No unrelated refactors.

--- a/docs/superpowers/specs/2026-08-07-profession-block-break-gates-design.md
+++ b/docs/superpowers/specs/2026-08-07-profession-block-break-gates-design.md
@@ -1,0 +1,130 @@
+# Profession-Gated Block Breaking
+
+**Date:** 2026-08-07
+**Status:** Draft for review
+
+## Problem
+
+Players can break any block regardless of their profession progression. The
+plugin already tracks profession levels (via the §8.1 `ProfessionCatalog` +
+job progression), but nothing restricts block breaking by level. This feature
+lets the server tie breaking to profession level: e.g. mining level 30
+required to break diamond ore.
+
+## Decisions (from design session)
+
+- **Hard gate**: cannot break at all below the required level. The
+  `BlockBreakEvent` is cancelled; the block stays; player gets a message on
+  each attempt.
+- **Check timing**: on break attempt, inside `BlockBreakEvent`.
+- **Config**: per-material entries. No category/`*` fallbacks.
+- **Profession**: explicit profession id per block entry — decoupled from the
+  paying job.
+- **Feedback**: message with reason; spam-rate-limiting not included in scope
+  (simple direct message per attempt).
+- **Bypass**: permission `modularjobs.bypassblockbreak`, `default: op`
+  (mirrors `modularjobs.admin`). Ops bypass by virtue of the default.
+- **Scope**: block ALL breaking of that material outright for unqualified
+  players. No tool/enchant-tier gating in this feature.
+
+## Config
+
+New section in `paper/src/main/resources/config.yml`:
+
+```yaml
+# Block breaking gates: minimum profession level required to break a material.
+# Material names are Minecraft keys (diamond_ore, ancient_debris, ...).
+# Professions are §8.1 catalog ids (mining, woodcutting, farming, ...).
+block-break-gates:
+  diamond_ore: { profession: mining, level: 30 }
+  deepslate_diamond_ore: { profession: mining, level: 30 }
+  ancient_debris: { profession: mining, level: 40 }
+```
+
+- Material key parsed via `Material.matchMaterial(...)`, case-insensitive;
+  unknown material → load warning, entry skipped.
+- Unknown/empty profession id → load warning, entry skipped.
+- `level <= 0` → load warning, entry skipped.
+- Section absent/empty → feature disabled entirely; zero overhead on break.
+
+## Components
+
+### api module (new)
+
+- `BlockBreakGate` — immutable record:
+  `(Material material, String professionId, int minLevel)`.
+- `BlockBreakGateService` — `@NotNull List<BlockBreakGate> gates()`,
+  `Optional<BlockBreakGate> gateFor(Material)`.
+  Kept in `api` so consumers outside `paper` (none today, but the profession
+  APIs are deliberately published) can read the gate table without Paper
+  internals.
+
+### paper module
+
+- `YamlBlockBreakGateLoader` — parses the `block-break-gates` section into
+  `List<BlockBreakGate>`; validates material/profession/level; logs warnings.
+  Pattern follows the existing config loaders (`SkillTreeConfigParser`,
+  `UpgradeTreeLoader`).
+- `BlockBreakGateStore` — immutable in-memory cache of loaded gates, keyed by
+  material (guava `ImmutableMap` or plain `Map`); mirrors
+  `MemoryBuffService`/`MemoryRecipeService`. Loaded once at startup from
+  `config.yml` (consistent with jobs.yml / job_tasks.yml — the plugin has no
+  central config reload path today); loader kept separately so a future
+  reload path can re-invoke it.
+- `BlockBreakGateListener` — Bukkit `Listener`:
+  - `@EventHandler(priority = NORMAL, ignoreCancelled = true)` on
+    `BlockBreakEvent`.
+  - Bypass: `event.getPlayer().hasPermission("modularjobs.bypassblockbreak")`
+    → return.
+  - Look up gate for `event.getBlock().getType()`; none → return.
+  - `ProfessionService.level(player, gate.professionId())`; empty (not joined)
+    or `< gate.minLevel()` → cancel + message.
+  - Message: `<error>Mining level <primary>30</primary> required to break
+    <secondary>diamond ore</secondary>` via existing `Messages` MiniMessage
+    tags.
+- Wire into `PluginContext`/`ProfessionWiring` composition root; register
+  listener in the bootstrap.
+
+### Priority ordering (critical)
+
+Existing `JobPaymentListener.onBlockBreak` runs at `MONITOR`. The gate fires
+at `NORMAL`, so a cancelled break never reaches pay logic, never populates
+`breakCache`, and never re-arms exploit protection. Denied break → no
+interaction with payment/exploit systems at all.
+
+### plugin.yml
+
+```yaml
+permissions:
+  modularjobs.bypassblockbreak:
+    description: Bypass profession-gated block breaking
+    default: op
+```
+
+## Error handling
+
+- Bad config entries never crash startup: warn + skip.
+- `ProfessionService.level` empty (player never joined that profession) is
+  treated as level 0 → blocked, message shown.
+- No gates configured → listener still registers but short-circuits on the
+  empty map lookup (negligible cost).
+
+## Testing
+
+- `api`: `BlockBreakGate` + service model test.
+- `paper` (MockBukkit):
+  - Loader: valid entries parse; bad material/profession/level warn & skip;
+    empty section → empty list.
+  - Listener: below level → `BlockBreakEvent` cancelled + message; at/above
+    level → not cancelled; no gate for material → not cancelled; bypass
+    permission → not cancelled; unjoined profession → cancelled.
+- Gate-level semantics reuse `ProfessionServiceTest`-style JSON fixtures if
+  needed; keep tests deterministic and isolated.
+
+## Non-goals
+
+- No soft-gate (deny pay but allow break).
+- No tool/enchantment tier gating.
+- No per-player config; gates are global.
+- No rate limiting of the denial message.
+- No GUI/editor surface for gates (config file only).

--- a/paper/src/main/java/net/aincraft/PluginContext.java
+++ b/paper/src/main/java/net/aincraft/PluginContext.java
@@ -51,7 +51,10 @@ import net.aincraft.gui.craftux.CraftuxUiHost;
 import net.aincraft.payable.PayableWiring;
 import net.aincraft.payment.PaymentWiring;
 import net.aincraft.placeholders.ModularJobsPlaceholderExpansion;
+import net.aincraft.profession.BlockBreakGateListener;
+import net.aincraft.profession.BlockBreakGateStore;
 import net.aincraft.profession.ProfessionWiring;
+import net.aincraft.profession.YamlBlockBreakGateLoader;
 import net.aincraft.protection.BlockOwnershipService;
 import net.aincraft.protection.BlockProtectionAdapter;
 import net.aincraft.protection.BlockProtectionAdapterProvider;
@@ -220,6 +223,9 @@ public final class PluginContext {
 
     ProfessionWiring professions = ProfessionWiring.create(domain.jobService);
 
+    BlockBreakGateStore blockBreakGateStore = new BlockBreakGateStore(
+        new YamlBlockBreakGateLoader(plugin.getLogger()).load(databaseConfig));
+
     UpgradePermissionManager permissionManager = new UpgradePermissionManager(plugin);
     UpgradeEffectApplier effectApplier =
         new UpgradeEffectApplier(permissionManager, professions.recipeService);
@@ -328,6 +334,8 @@ public final class PluginContext {
     // UpgradeTreeGui clicks are host craftux actions (no Bukkit Listener)
     listenerList.add(new UpgradePermissionRestoreListener(
         upgradeService, effectApplier, permissionManager, skillTreeRegistry));
+    // Profession-gated block breaking (cancel below configured level)
+    listenerList.add(new BlockBreakGateListener(blockBreakGateStore, professions.professionService));
 
     EventBus eventBus = new EventBus();
     Bridge bridge = new BridgeImpl(

--- a/paper/src/main/java/net/aincraft/profession/BlockBreakGateListener.java
+++ b/paper/src/main/java/net/aincraft/profession/BlockBreakGateListener.java
@@ -1,0 +1,57 @@
+package net.aincraft.profession;
+
+import java.util.Locale;
+import java.util.OptionalInt;
+import net.aincraft.service.ProfessionService;
+import net.aincraft.util.Messages;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Cancels breaking a material whose configured profession level requirement is unmet.
+ *
+ * <p>Runs at {@link EventPriority#NORMAL} so a cancelled break happens before the
+ * {@code MONITOR} payment listener, keeping denied breaks out of pay/exploit logic.
+ */
+public final class BlockBreakGateListener implements Listener {
+
+  public static final String BYPASS_PERMISSION = "modularjobs.bypassblockbreak";
+
+  private final BlockBreakGateStore store;
+  private final ProfessionService professionService;
+
+  public BlockBreakGateListener(
+      @NotNull BlockBreakGateStore store,
+      @NotNull ProfessionService professionService) {
+    this.store = store;
+    this.professionService = professionService;
+  }
+
+  @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
+  public void onBlockBreak(final BlockBreakEvent event) {
+    Player player = event.getPlayer();
+    if (player.hasPermission(BYPASS_PERMISSION)) {
+      return;
+    }
+    String materialKey = event.getBlock().getType().name().toLowerCase(Locale.ROOT);
+    BlockBreakGate gate = store.gateFor(materialKey).orElse(null);
+    if (gate == null) {
+      return;
+    }
+    OptionalInt level = professionService.level(player.getUniqueId(), gate.professionId());
+    if (level.isEmpty() || level.getAsInt() < gate.minLevel()) {
+      event.setCancelled(true);
+      Messages.send(player, gateMessage(gate));
+    }
+  }
+
+  private static String gateMessage(BlockBreakGate gate) {
+    return "<error>Level <primary>" + gate.minLevel()
+        + " <error>" + gate.professionId()
+        + " required to break <secondary>" + gate.materialKey() + "</secondary>";
+  }
+}

--- a/paper/src/main/java/net/aincraft/profession/BlockBreakGateStore.java
+++ b/paper/src/main/java/net/aincraft/profession/BlockBreakGateStore.java
@@ -1,0 +1,38 @@
+package net.aincraft.profession;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import net.aincraft.service.BlockBreakGateService;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Immutable in-memory gate table keyed by lowercase material key.
+ */
+public final class BlockBreakGateStore implements BlockBreakGateService {
+
+  private final Map<String, BlockBreakGate> byMaterial;
+
+  public BlockBreakGateStore(@NotNull List<BlockBreakGate> gates) {
+    Map<String, BlockBreakGate> map = gates.stream()
+        .collect(Collectors.toUnmodifiableMap(
+            g -> g.materialKey().toLowerCase(Locale.ROOT), g -> g));
+    this.byMaterial = Map.copyOf(map);
+  }
+
+  public boolean isEmpty() {
+    return byMaterial.isEmpty();
+  }
+
+  @Override
+  public @NotNull List<BlockBreakGate> gates() {
+    return List.copyOf(byMaterial.values());
+  }
+
+  @Override
+  public @NotNull Optional<BlockBreakGate> gateFor(@NotNull String materialKey) {
+    return Optional.ofNullable(byMaterial.get(materialKey.toLowerCase(Locale.ROOT)));
+  }
+}

--- a/paper/src/main/java/net/aincraft/profession/YamlBlockBreakGateLoader.java
+++ b/paper/src/main/java/net/aincraft/profession/YamlBlockBreakGateLoader.java
@@ -1,0 +1,68 @@
+package net.aincraft.profession;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.logging.Logger;
+import org.bukkit.Material;
+import org.bukkit.configuration.ConfigurationSection;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Parses the {@code block-break-gates} section of config.yml into {@link BlockBreakGate}s.
+ * Invalid entries (unknown material/profession, non-positive level) are skipped
+ * with a warning; a missing section yields an empty list.
+ */
+public final class YamlBlockBreakGateLoader {
+
+  private static final String SECTION = "block-break-gates";
+
+  private final Logger logger;
+
+  public YamlBlockBreakGateLoader(@NotNull Logger logger) {
+    this.logger = logger;
+  }
+
+  public @NotNull List<BlockBreakGate> load(@NotNull ConfigurationSection config) {
+    ConfigurationSection section = config.getConfigurationSection(SECTION);
+    if (section == null) {
+      return List.of();
+    }
+    List<BlockBreakGate> gates = new ArrayList<>();
+    for (String materialKey : section.getKeys(false)) {
+      if (section.isConfigurationSection(materialKey)) {
+        parseEntry(section.getConfigurationSection(materialKey), materialKey).ifPresent(gates::add);
+      }
+    }
+    return gates;
+  }
+
+  private java.util.Optional<BlockBreakGate> parseEntry(
+      ConfigurationSection entry, String materialKey) {
+    Material material = Material.matchMaterial(materialKey);
+    if (material == null || material == Material.AIR) {
+      logger.warning("block-break-gates: unknown material '" + materialKey + "' — skipping");
+      return java.util.Optional.empty();
+    }
+    String professionId = entry.getString("profession");
+    if (professionId == null
+        || !ProfessionCatalog.resolve(professionId).isPresent()) {
+      logger.warning("block-break-gates: '" + materialKey + "' has unknown profession '"
+          + professionId + "' — skipping");
+      return java.util.Optional.empty();
+    }
+    if (!entry.isInt("level")) {
+      logger.warning("block-break-gates: '" + materialKey + "' level must be an int — skipping");
+      return java.util.Optional.empty();
+    }
+    int level = entry.getInt("level");
+    if (level <= 0) {
+      logger.warning("block-break-gates: '" + materialKey + "' level must be > 0 — skipping");
+      return java.util.Optional.empty();
+    }
+    String canonical = ProfessionCatalog.resolve(professionId).orElseThrow()
+        .id().toLowerCase(Locale.ROOT);
+    return java.util.Optional.of(
+        new BlockBreakGate(materialKey.toLowerCase(Locale.ROOT), canonical, level));
+  }
+}

--- a/paper/src/main/resources/config.yml
+++ b/paper/src/main/resources/config.yml
@@ -19,6 +19,13 @@ economy:
 profession-apis:
   register-bukkit-services: false
 
+# Block breaking gates: minimum profession level required to break a material.
+# Material names are Minecraft keys (diamond_ore, ancient_debris, ...).
+# Professions are §8.1 catalog ids (mining, woodcutting, farming, ...).
+block-break-gates:
+  # diamond_ore: { profession: mining, level: 30 }
+  # deepslate_diamond_ore: { profession: mining, level: 30 }
+
 trackable_entities:
 
 # Color scheme for all command outputs

--- a/paper/src/main/resources/plugin.yml
+++ b/paper/src/main/resources/plugin.yml
@@ -49,3 +49,6 @@ permissions:
     default: op
     children:
       modularjobs.admin: true
+  modularjobs.bypassblockbreak:
+    description: Bypass profession-gated block breaking
+    default: op

--- a/paper/src/test/java/net/aincraft/profession/BlockBreakGateListenerTest.java
+++ b/paper/src/test/java/net/aincraft/profession/BlockBreakGateListenerTest.java
@@ -1,0 +1,135 @@
+package net.aincraft.profession;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.UUID;
+import net.aincraft.service.ProfessionService;
+import net.aincraft.test.MockBukkitSupport;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.ServerMock;
+
+class BlockBreakGateListenerTest {
+
+  private static final String BYPASS = "modularjobs.bypassblockbreak";
+
+  private StubProfessionService professions;
+
+  private record StubProfessionService(
+      java.util.Map<String, OptionalInt> levels) implements ProfessionService {
+
+    @Override
+    public List<net.aincraft.profession.ProfessionDefinition> tracks() {
+      return List.of();
+    }
+
+    @Override
+    public Optional<net.aincraft.profession.ProfessionDefinition> resolve(String idOrAlias) {
+      return net.aincraft.profession.ProfessionCatalog.resolve(idOrAlias);
+    }
+
+    @Override
+    public OptionalInt level(UUID playerId, String professionIdOrAlias) {
+      return levels.getOrDefault(professionIdOrAlias, OptionalInt.empty());
+    }
+
+    @Override
+    public Optional<java.math.BigDecimal> experience(UUID playerId, String professionIdOrAlias) {
+      return Optional.empty();
+    }
+
+    @Override
+    public boolean ensureTrack(UUID playerId, String professionIdOrAlias) {
+      return true;
+    }
+  }
+
+  private BlockBreakGateListener listener;
+  private Player player;
+
+  @BeforeEach
+  void setUp() {
+    MockBukkitSupport.mockServer();
+    professions = new StubProfessionService(new java.util.HashMap<>());
+    BlockBreakGateStore store = new BlockBreakGateStore(List.of(
+        new BlockBreakGate("diamond_ore", "mining", 30)));
+    listener = new BlockBreakGateListener(store, professions);
+    player = MockBukkitSupport.mockServer().addPlayer();
+  }
+
+  @AfterEach
+  void tearDown() {
+    MockBukkitSupport.unmockServer();
+  }
+
+  @Test
+  void belowRequiredLevelCancelsBreak() {
+    professions.levels().put("mining", OptionalInt.of(29));
+    assertTrue(breakEvent().isCancelled());
+  }
+
+  @Test
+  void atRequiredLevelAllowsBreak() {
+    professions.levels().put("mining", OptionalInt.of(30));
+    assertFalse(breakEvent().isCancelled());
+  }
+
+  @Test
+  void aboveRequiredLevelAllowsBreak() {
+    professions.levels().put("mining", OptionalInt.of(45));
+    assertFalse(breakEvent().isCancelled());
+  }
+
+  @Test
+  void unjoinedProfessionCancelsBreak() {
+    // no level entry -> OptionalInt.empty -> treated as level 0
+    assertTrue(breakEvent().isCancelled());
+  }
+
+  @Test
+  void ungatedMaterialAllowsBreak() {
+    Block block = mockBlock(Material.STONE);
+    BlockBreakEvent event = new BlockBreakEvent(block, player);
+    listener.onBlockBreak(event);
+    assertFalse(event.isCancelled());
+  }
+
+  @Test
+  void bypassPermissionAllowsBreak() {
+    professions.levels().put("mining", OptionalInt.of(1));
+    ServerMock server = MockBukkitSupport.mockServer();
+    org.mockbukkit.mockbukkit.plugin.PluginMock plugin =
+        org.mockbukkit.mockbukkit.plugin.PluginMock.builder()
+            .withPluginName("MockBukkit")
+            .build();
+    server.getPluginManager().registerLoadedPlugin(plugin);
+    player.addAttachment(plugin).setPermission(BYPASS, true);
+    assertFalse(breakEvent().isCancelled());
+  }
+
+  private BlockBreakEvent breakEvent() {
+    Block block = mockBlock(Material.DIAMOND_ORE);
+    BlockBreakEvent event = new BlockBreakEvent(block, player);
+    listener.onBlockBreak(event);
+    return event;
+  }
+
+  private Block mockBlock(Material material) {
+    var server = org.bukkit.Bukkit.getServer();
+    org.bukkit.World world = server.getWorlds().isEmpty()
+        ? server.createWorld(new org.bukkit.WorldCreator("world"))
+        : server.getWorlds().getFirst();
+    Block block = world.getBlockAt(0, 64, 0);
+    block.setType(material);
+    return block;
+  }
+}

--- a/paper/src/test/java/net/aincraft/profession/YamlBlockBreakGateLoaderTest.java
+++ b/paper/src/test/java/net/aincraft/profession/YamlBlockBreakGateLoaderTest.java
@@ -1,0 +1,85 @@
+package net.aincraft.profession;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.logging.Logger;
+import net.aincraft.test.MockBukkitSupport;
+import org.bukkit.Material;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class YamlBlockBreakGateLoaderTest {
+
+  private YamlBlockBreakGateLoader loader;
+
+  @BeforeEach
+  void setUp() {
+    MockBukkitSupport.mockServer();
+    loader = new YamlBlockBreakGateLoader(Logger.getLogger("test"));
+  }
+
+  @AfterEach
+  void tearDown() {
+    MockBukkitSupport.unmockServer();
+  }
+
+  @Test
+  void parsesValidGateEntries() {
+    YamlConfiguration config = new YamlConfiguration();
+    config.set("block-break-gates.diamond_ore.profession", "mining");
+    config.set("block-break-gates.diamond_ore.level", 30);
+    config.set("block-break-gates.ancient_debris.profession", "mining");
+    config.set("block-break-gates.ancient_debris.level", 40);
+
+    List<BlockBreakGate> gates = loader.load(config);
+
+    assertEquals(2, gates.size());
+    BlockBreakGate diamond = gates.stream()
+        .filter(g -> g.materialKey().equals("diamond_ore"))
+        .findFirst().orElseThrow();
+    assertEquals("mining", diamond.professionId());
+    assertEquals(30, diamond.minLevel());
+    assertTrue(Material.matchMaterial(diamond.materialKey()) != null);
+  }
+
+  @Test
+  void skipsInvalidEntriesWithWarnings() {
+    YamlConfiguration config = new YamlConfiguration();
+    // Unknown material
+    config.set("block-break-gates.not_a_real_material.profession", "mining");
+    config.set("block-break-gates.not_a_real_material.level", 30);
+    // Unknown profession
+    config.set("block-break-gates.stone.profession", "not_a_profession");
+    config.set("block-break-gates.stone.level", 5);
+    // Non-int level
+    config.set("block-break-gates.dirt.profession", "farming");
+    config.set("block-break-gates.dirt.level", "high");
+    // Zero/negative level
+    config.set("block-break-gates.sand.profession", "mining");
+    config.set("block-break-gates.sand.level", 0);
+
+    List<BlockBreakGate> gates = loader.load(config);
+    assertTrue(gates.isEmpty());
+  }
+
+  @Test
+  void emptyOrMissingSectionYieldsEmptyList() {
+    YamlConfiguration empty = new YamlConfiguration();
+    assertTrue(loader.load(empty).isEmpty());
+  }
+
+  @Test
+  void storeLooksUpCaseInsensitively() {
+    BlockBreakGateStore store = new BlockBreakGateStore(
+        List.of(new BlockBreakGate("diamond_ore", "mining", 30)));
+    assertTrue(store.gateFor("DIAMOND_ORE").isPresent());
+    assertTrue(store.gateFor("stone").isEmpty());
+    assertFalse(store.isEmpty());
+    assertTrue(new BlockBreakGateStore(List.of()).isEmpty());
+  }
+}

--- a/web/astro.config.mjs
+++ b/web/astro.config.mjs
@@ -11,7 +11,7 @@ export default defineConfig({
 
   integrations: [starlight({
       title: 'Modular Jobs',
-      social: [{ icon: 'github', label: 'GitHub', href: 'https://github.com/mintychochip/modularjobs' }],
+      social: [{ icon: 'github', label: 'GitHub', href: 'https://github.com/aincraft-org/modularjobs' }],
     sidebar: [
           {
               label: 'Guides',

--- a/web/src/components/Info.astro
+++ b/web/src/components/Info.astro
@@ -8,7 +8,7 @@ import InfoCard from './InfoCard.astro'
 </InfoCard>
 <InfoCard
     description="Browse the plugin's source code, report issues and contribute to the project"
-    link="https:github.com/mintychochip/modularjobs">
+    link="https://github.com/aincraft-org/modularjobs">
   <div class="flex items-center gap-2">
     <img src="/GitHub_Invertocat_Light.svg" alt="Github Logo" class="h-6">
     <h3>Github</h3>

--- a/web/src/components/NavBar.astro
+++ b/web/src/components/NavBar.astro
@@ -19,7 +19,7 @@
       />
     </a>
     <a
-        href="https://github.com/mintychochip/ModularJobs"
+        href="https://github.com/aincraft-org/modularjobs"
         target="_blank"
         rel="noopener"
         class="btn btn-ghost btn-circle"


### PR DESCRIPTION
## What

Restricts block breaking by profession level: a player below the configured minimum level for a material cannot break it (event cancelled + themed message).

## Config

```yaml
block-break-gates:
  diamond_ore: { profession: mining, level: 30 }
```

Per-material explicit profession id (\u00a78.1 catalog). Empty/absent section = feature off. Invalid entries warn + skip. Bypass: `modularjobs.bypassblockbreak` (op).

## Implementation

- api: `BlockBreakGate` + `BlockBreakGateService` (paper-free)
- paper: `YamlBlockBreakGateLoader` (warn+skip), immutable `BlockBreakGateStore`, `BlockBreakGateListener` at NORMAL priority (cancels before the MONITOR pay listener)
- wired in `PluginContext`; config.yml sample; plugin.yml permission

## Tests

12 new tests (api contract, loader/store, listener incl. bypass + unjoined = blocked). Full suite green: `:api:test :common:test :paper:test`.